### PR TITLE
Added "data-" to fields, so page maintains HTML5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cordova plugin add https://github.com/mrchandoo/cordova-plugin-decimal-keyboard.
 ## Usage
 
 ```
-<input type="text" pattern="[0-9]*" decimal="true">
+<input type="text" pattern="[0-9]*" data-decimal="true">
 ```
 Input type number will not work, try to use text with [0-9] pattern instead.
 
@@ -20,14 +20,14 @@ Input type number will not work, try to use text with [0-9] pattern instead.
 ### Multiple decimals
 
 ```
-<input type="text" pattern="[0-9]*" decimal="true" allow-multiple-decimals="true">
+<input type="text" pattern="[0-9]*" data-decimal="true" data-allow-multiple-decimals="true">
 ```
 <img src=https://github.com/mrchandoo/cordova-plugin-decimal-keyboard/blob/master/screenshots/Multiple%20Decimals.PNG width=25% height=25% />
 
 ### Different decimal character
 
 ```
-<input type="text" pattern="[0-9]*" decimal="true" allow-multiple-decimals="false" decimal-char=",">
+<input type="text" pattern="[0-9]*" data-decimal="true" data-allow-multiple-decimals="false" decimal-char=",">
 ```
 If you want to localize decimal character, you can change using decimal-char attribute  
 <img src=https://github.com/mrchandoo/cordova-plugin-decimal-keyboard/blob/master/screenshots/Different%20Decimal%20Char.PNG width=25% height=25% />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-decimal-keyboard" version="1.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-decimal-keyboard" version="1.1">
     <name>Decimal Keyboard</name>
     <description>Cordova Decimal Keyboard Plugin</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVDecimalKeyboard.m
+++ b/src/ios/CDVDecimalKeyboard.m
@@ -59,7 +59,7 @@ BOOL isAppInBackground=NO;
     decimalButton = [UIButton buttonWithType:UIButtonTypeCustom];
     [self setDecimalChar];
     [decimalButton setTitleColor:[UIColor colorWithRed:0/255.0 green:0/255.0 blue:0/255.0 alpha:1.0] forState:UIControlStateNormal];
-    decimalButton.titleLabel.font = [UIFont systemFontOfSize:40.0];
+    decimalButton.titleLabel.font = [UIFont systemFontOfSize:30.0];
     [decimalButton addTarget:self action:@selector(buttonPressed:)
             forControlEvents:UIControlEventTouchUpInside];
     [decimalButton addTarget:self action:@selector(buttonTapped:)

--- a/www/decimal-keyboard.js
+++ b/www/decimal-keyboard.js
@@ -11,9 +11,9 @@ DecimalKeyboard.getActiveElementType= function(){
 DecimalKeyboard.isDecimal = function(){
 	var showDecimal = null;
 	var activeElement = document.activeElement;
-	if(activeElement.attributes["decimal"]==undefined || 
-		activeElement.attributes["decimal"]=='undefined' || 
-		activeElement.attributes["decimal"].value=='false'){
+	if(activeElement.attributes["data-decimal"]==undefined || 
+		activeElement.attributes["data-decimal"]=='undefined' || 
+		activeElement.attributes["data-decimal"].value=='false'){
 		showDecimal = false;
 	}else{
 		showDecimal = true;
@@ -26,11 +26,11 @@ DecimalKeyboard.getDecimalChar = function(activeElement){
 		activeElement = document.activeElement;
 
 	var decimalChar = null;
-	if(activeElement.attributes["decimal-char"]==undefined || 
-		activeElement.attributes["decimal-char"]=='undefined'){
+	if(activeElement.attributes["data-decimal-char"]==undefined || 
+		activeElement.attributes["data-decimal-char"]=='undefined'){
 		decimalChar='.'
 	}else{
-		decimalChar=activeElement.attributes["decimal-char"].value;
+		decimalChar=activeElement.attributes["data-decimal-char"].value;
 	}
 	return decimalChar;
 };
@@ -40,9 +40,9 @@ DecimalKeyboard.addDecimalAtPos = function(val,position){
 DecimalKeyboard.addDecimal = function(){
 	var activeElement = document.activeElement;
 	var allowMultipleDecimals = true;
-	if(activeElement.attributes["allow-multiple-decimals"]==undefined || 
-		activeElement.attributes["allow-multiple-decimals"]=='undefined' || 
-		activeElement.attributes["allow-multiple-decimals"].value=='false'){
+	if(activeElement.attributes["data-allow-multiple-decimals"]==undefined || 
+		activeElement.attributes["data-allow-multiple-decimals"]=='undefined' || 
+		activeElement.attributes["data-allow-multiple-decimals"].value=='false'){
 		allowMultipleDecimals = false;
 	}
 	var value = activeElement.value;


### PR DESCRIPTION
Added "data-" to custom attribute fields, so page maintains HTML5 compatibility (some code generating platforms will not allow invalid fields, so this mitigates that problem).
Also reduced decimal separator size for aesthetic purposes (this could be a parameter in the config, but haven't applied it in this change).