### PR TITLE
invalid pattern error

### DIFF
--- a/src/ios/CDVDecimalKeyboard.m
+++ b/src/ios/CDVDecimalKeyboard.m
@@ -168,7 +168,7 @@ BOOL isDifferentKeyboardShown=NO;
 - (void) isTextAndDecimal:(void (^)(BOOL isTextAndDecimal))completionHandler {
     [self evaluateJavaScript:@"DecimalKeyboard.getActiveElementType();"
            completionHandler:^(NSString * _Nullable response, NSError * _Nullable error) {
-               BOOL isText = [response isEqual:@"text"];
+               BOOL isText = [response isEqual:@"tel"];
                
                if (isText) {
                    [self evaluateJavaScript:@"DecimalKeyboard.isDecimal();"


### PR DESCRIPTION
Invalid patter error was coming as the pattern was set 0-9 and we were entering a dot in the text box,
so just removed the condition to add pattern and use type equal text for adding dot button on keyboard UI by adding type tel in input box